### PR TITLE
spike: don't initialize final_metrics_map in Axon.Loop

### DIFF
--- a/lib/axon/loop.ex
+++ b/lib/axon/loop.ex
@@ -1640,12 +1640,14 @@ defmodule Axon.Loop do
       Logger.debug("Axon.Loop finished initializing loop state in #{us_to_ms(time)}ms")
     end
 
-    final_metrics_map =
-      for i <- epoch_start..epoch_end do
-        {i, Map.new(metric_fns, fn {k, _} -> {k, Nx.tensor(0)} end)}
-      end
-      |> Map.new()
-      |> Map.merge(loop_state.metrics)
+    # final_metrics_map =
+    #   for i <- epoch_start..epoch_end do
+    #     {i, Map.new(metric_fns, fn {k, _} -> {k, Nx.tensor(0)} end)}
+    #   end
+    #   |> Map.new()
+    #   |> Map.merge(loop_state.metrics)
+
+    final_metrics_map = loop_state.metrics
 
     # TODO: Can we infer here?
     zero_metrics =
@@ -1712,8 +1714,9 @@ defmodule Axon.Loop do
                             |> Map.take(Map.keys(metric_fns))
                             |> Map.new(fn {k, v} -> {k, zeros_like(v)} end)
 
-                          final_metrics_map =
-                            Map.replace!(final_metrics_map, epoch, state.metrics)
+                          # final_metrics_map =
+                          #   Map.replace!(final_metrics_map, epoch, state.metrics)
+                          final_metrics_map = Map.put(final_metrics_map, epoch, state.metrics)
 
                           {:cont,
                            {batch_fn, final_metrics_map,


### PR DESCRIPTION
**The PR does not propose any solution, it is just to to highlight the possible root cause of https://github.com/elixir-nx/axon/issues/430**

- `Axon.Loop` initializes the map with the final metrics and passes it through the whole training.
- In the `final_metrics_map` there as much keys as the number of epochs
- The time spent on garbage collection increases when the number of epochs is higher (as the benchmark in the linked PR shows)
- The bench

The benchmark results below shows that the training is faster and  if the `final_metrics_map` is not fully initialized, at least are better for the first epochs, then I expect they will degrade when the map starts to be bigger.

```
Name             ips        average  deviation         median         99th %
10_000          0.42         2.37 s     ±0.00%         2.37 s         2.37 s
100             0.42         2.37 s     ±0.00%         2.37 s         2.37 s
1000            0.42         2.37 s     ±0.00%         2.37 s         2.37 s

Comparison:
10_000          0.42
100             0.42 - 1.00x slower +0.00040 s
1000            0.42 - 1.00x slower +0.00360 s

Memory usage statistics:

Name      Memory usage
10_000       175.26 MB
100          173.53 MB - 0.99x memory usage -1.73569 MB
1000         175.26 MB - 1.00x memory usage +0 MB
```

